### PR TITLE
fix: 초대 시 초대한 사람과 초대할 워크스페이스를 받고, 메일 전송 로직을 도메인 모델로 이동

### DIFF
--- a/src/main/java/com/finnect/workspace/adaptor/in/web/WorkspaceController.java
+++ b/src/main/java/com/finnect/workspace/adaptor/in/web/WorkspaceController.java
@@ -2,6 +2,8 @@ package com.finnect.workspace.adaptor.in.web;
 
 import com.finnect.common.ApiUtils;
 import com.finnect.common.ApiUtils.ApiResult;
+import com.finnect.user.application.port.in.FindUsernameUseCase;
+import com.finnect.user.application.port.in.command.FindUsernameCommand;
 import com.finnect.user.vo.WorkspaceAuthority;
 import com.finnect.workspace.domain.state.WorkspaceState;
 import com.finnect.workspace.adaptor.in.web.req.CreateWorkspaceRequest;
@@ -35,6 +37,7 @@ public class WorkspaceController {
     private final RenameWorkspaceUsecase renameWorkspaceUsecase;
     private final InviteMembersUsecase inviteMembersUsecase;
     private final GetWorkspaceQuery getWorkspaceQuery;
+    private final FindUsernameUseCase findUsernameUseCase;
 
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/workspaces")
@@ -104,9 +107,26 @@ public class WorkspaceController {
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/workspaces/invitation")
     public ResponseEntity<ApiResult<InviteMembersResponse>> inviteMembers(@RequestBody InviteMembersRequest request) {
+        Long userId;
+        try {
+            userId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getDetails().toString());
+        } catch (Exception e) {
+            throw new RuntimeException("토큰에 사용자 ID가 누락되었습니다.");
+        }
+        Long workspaceId;
+        try {
+            workspaceId = WorkspaceAuthority.from(
+                    SecurityContextHolder.getContext().getAuthentication().getAuthorities()
+            ).workspaceId().value();
+        } catch (Exception e) {
+            throw new RuntimeException("워크스페이스 ID가 누락되었습니다.");
+        }
+
         List<InviteMembersCommand> cmds = request.getEmails()
                 .stream()
-                .map(InviteMembersCommand::new)
+                .map((email) -> new InviteMembersCommand(email,
+                        "임의의 이름",
+                        getWorkspaceQuery.getWorkspace(workspaceId).getWorkspaceName()))
                 .collect(Collectors.toList());
 
         List<InvitationDto> invitations = inviteMembersUsecase.inviteMembers(cmds)

--- a/src/main/java/com/finnect/workspace/adaptor/in/web/WorkspaceController.java
+++ b/src/main/java/com/finnect/workspace/adaptor/in/web/WorkspaceController.java
@@ -37,7 +37,6 @@ public class WorkspaceController {
     private final RenameWorkspaceUsecase renameWorkspaceUsecase;
     private final InviteMembersUsecase inviteMembersUsecase;
     private final GetWorkspaceQuery getWorkspaceQuery;
-    private final FindUsernameUseCase findUsernameUseCase;
 
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/workspaces")
@@ -124,9 +123,7 @@ public class WorkspaceController {
 
         List<InviteMembersCommand> cmds = request.getEmails()
                 .stream()
-                .map((email) -> new InviteMembersCommand(email,
-                        "임의의 이름",
-                        getWorkspaceQuery.getWorkspace(workspaceId).getWorkspaceName()))
+                .map((email) -> new InviteMembersCommand(email, userId, workspaceId))
                 .collect(Collectors.toList());
 
         List<InvitationDto> invitations = inviteMembersUsecase.inviteMembers(cmds)

--- a/src/main/java/com/finnect/workspace/adaptor/in/web/res/dto/InvitationDto.java
+++ b/src/main/java/com/finnect/workspace/adaptor/in/web/res/dto/InvitationDto.java
@@ -8,18 +8,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class InvitationDto implements InvitationState {
+public class InvitationDto {
     String email;
     Boolean succeed;
 
     public InvitationDto(InvitationState state) {
         this.email = state.getReceiver();
         this.succeed = state.getSucceed();
-    }
-
-
-    @Override
-    public String getReceiver() {
-        return this.email;
     }
 }

--- a/src/main/java/com/finnect/workspace/adaptor/in/web/res/dto/InvitationDto.java
+++ b/src/main/java/com/finnect/workspace/adaptor/in/web/res/dto/InvitationDto.java
@@ -13,7 +13,13 @@ public class InvitationDto implements InvitationState {
     Boolean succeed;
 
     public InvitationDto(InvitationState state) {
-        this.email = state.getEmail();
+        this.email = state.getReceiver();
         this.succeed = state.getSucceed();
+    }
+
+
+    @Override
+    public String getReceiver() {
+        return this.email;
     }
 }

--- a/src/main/java/com/finnect/workspace/application/InviteMembersService.java
+++ b/src/main/java/com/finnect/workspace/application/InviteMembersService.java
@@ -1,5 +1,6 @@
 package com.finnect.workspace.application;
 
+import com.finnect.workspace.application.port.in.GetWorkspaceQuery;
 import com.finnect.workspace.domain.state.InvitationState;
 import com.finnect.workspace.application.port.in.InviteMembersCommand;
 import com.finnect.workspace.application.port.in.InviteMembersUsecase;
@@ -21,6 +22,7 @@ import java.util.List;
 public class InviteMembersService implements InviteMembersUsecase {
     private final JavaMailSender javaMailSender;
     private final SpringTemplateEngine templateEngine;
+    private final GetWorkspaceQuery getWorkspaceQuery;
     @Override
     public List<InvitationState> inviteMembers(List<InviteMembersCommand> cmds) {
 
@@ -30,8 +32,8 @@ public class InviteMembersService implements InviteMembersUsecase {
         for (InviteMembersCommand cmd : cmds) {
             Invitation invitation = Invitation.of(
                     cmd.getEmail(),
-                    cmd.getSenderName(),
-                    cmd.getWorkspaceName()
+                    "임의의 이름",
+                    getWorkspaceQuery.getWorkspace(cmd.getWorkspaceId()).getWorkspaceName()
             );
 
             invitation.sendEmail(javaMailSender, templateEngine);

--- a/src/main/java/com/finnect/workspace/application/InviteMembersService.java
+++ b/src/main/java/com/finnect/workspace/application/InviteMembersService.java
@@ -4,16 +4,11 @@ import com.finnect.workspace.domain.state.InvitationState;
 import com.finnect.workspace.application.port.in.InviteMembersCommand;
 import com.finnect.workspace.application.port.in.InviteMembersUsecase;
 import com.finnect.workspace.domain.Invitation;
-import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
-import org.springframework.mail.javamail.MimeMessagePreparator;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
 import java.util.ArrayList;
@@ -24,14 +19,8 @@ import java.util.List;
 @Transactional
 @Slf4j
 public class InviteMembersService implements InviteMembersUsecase {
-
     private final JavaMailSender javaMailSender;
     private final SpringTemplateEngine templateEngine;
-
-    private static String username = "김아무개";
-    private static String workspaceName = "네이버의 워크스페이스";
-    private static String invitaionUrl = "https://localhost:8080";
-
     @Override
     public List<InvitationState> inviteMembers(List<InviteMembersCommand> cmds) {
 
@@ -39,39 +28,16 @@ public class InviteMembersService implements InviteMembersUsecase {
 
         // SMTP로 이메일 전송
         for (InviteMembersCommand cmd : cmds) {
-            String receiver = cmd.getEmail();
+            Invitation invitation = Invitation.of(
+                    cmd.getEmail(),
+                    cmd.getSenderName(),
+                    cmd.getWorkspaceName()
+            );
 
-            boolean result = sendEmail(receiver);
-            invitations.add(new Invitation(receiver, result));
+            invitation.sendEmail(javaMailSender, templateEngine);
+            invitations.add(invitation);
         }
 
         return invitations;
-    }
-
-    private boolean sendEmail(String receiver) {
-        MimeMessagePreparator perparator = new MimeMessagePreparator() {
-            @Override
-            public void prepare(MimeMessage mimeMessage) throws Exception {
-                MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
-
-                Context context = new Context();
-                context.setVariable("username", username);
-                context.setVariable("workspace_name", workspaceName);
-                context.setVariable("invite_url", invitaionUrl);
-
-                helper.setTo(receiver);
-                helper.setSubject("[Finnect] 귀하를 워크스페이스에 초대합니다.");
-
-                String htmlContent = templateEngine.process("email", context);
-                helper.setText(htmlContent, true);
-            }
-        };
-
-        try {
-            this.javaMailSender.send(perparator);
-        } catch (MailException e) {
-            return false;
-        }
-        return true;
     }
 }

--- a/src/main/java/com/finnect/workspace/application/InviteMembersService.java
+++ b/src/main/java/com/finnect/workspace/application/InviteMembersService.java
@@ -28,12 +28,14 @@ public class InviteMembersService implements InviteMembersUsecase {
 
         List<InvitationState> invitations = new ArrayList<>();
 
+        String workspaceName = getWorkspaceQuery.getWorkspace(cmds.get(0).getWorkspaceId()).getWorkspaceName();
+
         // SMTP로 이메일 전송
         for (InviteMembersCommand cmd : cmds) {
             Invitation invitation = Invitation.of(
                     cmd.getEmail(),
                     "임의의 이름",
-                    getWorkspaceQuery.getWorkspace(cmd.getWorkspaceId()).getWorkspaceName()
+                    workspaceName
             );
 
             invitation.sendEmail(javaMailSender, templateEngine);

--- a/src/main/java/com/finnect/workspace/application/port/in/InviteMembersCommand.java
+++ b/src/main/java/com/finnect/workspace/application/port/in/InviteMembersCommand.java
@@ -1,6 +1,7 @@
 package com.finnect.workspace.application.port.in;
 
 import com.finnect.common.SelfValidating;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
 
@@ -9,26 +10,26 @@ import java.util.regex.Pattern;
 
 @Getter
 public class InviteMembersCommand extends SelfValidating<InviteMembersCommand> {
-    @NotEmpty(message = "e-mail은 공백이거나 빈 문자열일 수 없습니다.")
+    @NotEmpty(message = "e-mail은 공백이거나 빈 문자열일 수 없습니다.") @Email
     private final String email;
+    private final String senderName;
+    private final String workspaceName;
 
     private static final String EMAIL_PATTERN = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@" + "(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
     private static final Pattern pattern = Pattern.compile(EMAIL_PATTERN);
 
-    public InviteMembersCommand(String email) {
+    public InviteMembersCommand(String email, String senderName, String workspaceName) {
         this.email = email;
-        isSmallerThan(this.email, 50);
+        isSmallerThan("email", this.email, 50);
+        this.senderName = senderName;
+        isSmallerThan("senderName", this.senderName, 50);
+        this.workspaceName = workspaceName;
+        isSmallerThan("workspaceName", this.workspaceName, 50);
         this.validateSelf();
     }
 
-    private void isSmallerThan(String name, int size) {
-        if (name.getBytes(StandardCharsets.UTF_8).length > size)
-            throw new RuntimeException("e-mail은 " + size + "byte보다 작거나 같아야 합니다.");
-    }
-
-    private void checkEmailFormat(String email) {
-        if (pattern.matcher(email).matches())
-            return;
-        throw new RuntimeException("e-mail의 형식이 올바르지 않습니다.");
+    private void isSmallerThan(String fieldName, String value, int size) {
+        if (value.getBytes(StandardCharsets.UTF_8).length > size)
+            throw new RuntimeException(fieldName + "은/는 " + size + "byte보다 작거나 같아야 합니다.");
     }
 }

--- a/src/main/java/com/finnect/workspace/application/port/in/InviteMembersCommand.java
+++ b/src/main/java/com/finnect/workspace/application/port/in/InviteMembersCommand.java
@@ -3,6 +3,7 @@ package com.finnect.workspace.application.port.in;
 import com.finnect.common.SelfValidating;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 import java.nio.charset.StandardCharsets;
@@ -12,19 +13,19 @@ import java.util.regex.Pattern;
 public class InviteMembersCommand extends SelfValidating<InviteMembersCommand> {
     @NotEmpty(message = "e-mail은 공백이거나 빈 문자열일 수 없습니다.") @Email
     private final String email;
-    private final String senderName;
-    private final String workspaceName;
+    @NotNull(message = "User ID는 null일 수 없습니다.")
+    private final Long userId;
+    @NotNull(message = "Workspace ID는 null일 수 없습니다.")
+    private final Long workspaceId;
 
     private static final String EMAIL_PATTERN = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@" + "(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
     private static final Pattern pattern = Pattern.compile(EMAIL_PATTERN);
 
-    public InviteMembersCommand(String email, String senderName, String workspaceName) {
+    public InviteMembersCommand(String email, Long senderId, Long workspaceId) {
         this.email = email;
         isSmallerThan("email", this.email, 50);
-        this.senderName = senderName;
-        isSmallerThan("senderName", this.senderName, 50);
-        this.workspaceName = workspaceName;
-        isSmallerThan("workspaceName", this.workspaceName, 50);
+        this.userId = senderId;
+        this.workspaceId = workspaceId;
         this.validateSelf();
     }
 

--- a/src/main/java/com/finnect/workspace/domain/Invitation.java
+++ b/src/main/java/com/finnect/workspace/domain/Invitation.java
@@ -3,6 +3,7 @@ package com.finnect.workspace.domain;
 import com.finnect.workspace.domain.state.InvitationState;
 import jakarta.mail.internet.MimeMessage;
 import lombok.*;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -14,6 +15,7 @@ import static lombok.AccessLevel.PRIVATE;
 
 @AllArgsConstructor(access = PRIVATE) @Builder(access = PRIVATE)
 @Getter
+@Slf4j
 public class Invitation implements InvitationState {
     private String receiver;
     private Boolean succeed;
@@ -25,6 +27,7 @@ public class Invitation implements InvitationState {
     public static Invitation of(String receiverEmail, String senderName, String workspaceName) {
         return Invitation.builder()
                 .receiver(receiverEmail)
+                .succeed(Boolean.FALSE)
                 .sender(senderName)
                 .workspaceName(workspaceName)
                 .build();
@@ -54,7 +57,7 @@ public class Invitation implements InvitationState {
         try {
             javaMailSender.send(perparator);
         } catch (MailException e) {
-            updateResult(Boolean.FALSE);
+            log.info(receiver + "에 대한 초대를 실패했습니다.");
             return;
         }
         updateResult(Boolean.TRUE);

--- a/src/main/java/com/finnect/workspace/domain/Invitation.java
+++ b/src/main/java/com/finnect/workspace/domain/Invitation.java
@@ -1,12 +1,62 @@
 package com.finnect.workspace.domain;
 
 import com.finnect.workspace.domain.state.InvitationState;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import jakarta.mail.internet.MimeMessage;
+import lombok.*;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.mail.javamail.MimeMessagePreparator;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
 
-@AllArgsConstructor
+import static lombok.AccessLevel.PRIVATE;
+
+@AllArgsConstructor(access = PRIVATE) @Builder(access = PRIVATE)
 @Getter
 public class Invitation implements InvitationState {
-    private String email;
+    private String receiver;
     private Boolean succeed;
+    private final String sender;
+    private final String workspaceName;
+
+    private static String invitaionUrl = "https://localhost:8008";
+
+    public static Invitation of(String receiverEmail, String senderName, String workspaceName) {
+        return Invitation.builder()
+                .receiver(receiverEmail)
+                .sender(senderName)
+                .workspaceName(workspaceName)
+                .build();
+    }
+
+    private void updateResult(Boolean result) {
+        this.succeed = result;
+    }
+
+    public void sendEmail(JavaMailSender javaMailSender, SpringTemplateEngine templateEngine) {
+        MimeMessagePreparator perparator = new MimeMessagePreparator() {
+            @Override
+            public void prepare(MimeMessage mimeMessage) throws Exception {
+                MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+
+                helper.setTo(receiver);
+                helper.setSubject("[Finnect] 귀하를 워크스페이스에 초대합니다.");
+
+                Context context = new Context();
+                context.setVariable("username", sender);
+                context.setVariable("workspace_name", workspaceName);
+                context.setVariable("invite_url", invitaionUrl);
+                helper.setText(templateEngine.process("email", context), true);
+            }
+        };
+
+        try {
+            javaMailSender.send(perparator);
+        } catch (MailException e) {
+            updateResult(Boolean.FALSE);
+            return;
+        }
+        updateResult(Boolean.TRUE);
+    }
 }

--- a/src/main/java/com/finnect/workspace/domain/state/InvitationState.java
+++ b/src/main/java/com/finnect/workspace/domain/state/InvitationState.java
@@ -2,7 +2,7 @@ package com.finnect.workspace.domain.state;
 
 public interface InvitationState {
 
-    String getEmail();
+    String getReceiver();
 
     Boolean getSucceed();
 }


### PR DESCRIPTION
### ✨ 작업 내용
---
- 초대 코드를 서비스에서 도메인 모델로 옮겼습니다.
- 초대할 때 초대한 사람의 이름과 워크스페이스의 이름을 받도록 수정하였습니다.
- 가입한 사람만 초대하도록 제한하였습니다.

### ✨ 참고 사항
---
- UserId를 통해 Username을 받아오는 로직이 필요합니다.
- 초대한 사람을 위한 URL이 필요합니다.

### ⏰ 현재 버그
---
- 존재하지 않는 이메일에 대한 초대가 성공으로 반환되고, SMTP 서버에서 재시도를 반복합니다.

### ✏ Git Close
